### PR TITLE
여행 상세보기 -> 태그된 친구 프로필 띄우기 기능

### DIFF
--- a/src/components/travel/item/TravelViewItem.vue
+++ b/src/components/travel/item/TravelViewItem.vue
@@ -8,45 +8,15 @@
         </div>
         <div class="col-md-4 user-text">
           <div class="avatar-group mt-2">
-            <a
-              href="javascript:;"
-              class="avatar avatar-l rounded-circle"
-              data-bs-toggle="tooltip"
-              data-bs-placement="bottom"
-              title
-              data-bs-original-title="Ryan Tompson"
-            >
-              <img src="@/assets/img/team-1.jpg" alt="team1" />
-            </a>
-            <a
-              href="javascript:;"
-              class="avatar avatar-l rounded-circle"
-              data-bs-toggle="tooltip"
-              data-bs-placement="bottom"
-              title
-              data-bs-original-title="Romina Hadid"
-            >
-              <img src="@/assets/img/team-2.jpg" alt="team2" />
-            </a>
-            <a
-              href="javascript:;"
-              class="avatar avatar-l rounded-circle"
-              data-bs-toggle="tooltip"
-              data-bs-placement="bottom"
-              title
-              data-bs-original-title="Alexander Smith"
-            >
-              <img src="@/assets/img/team-3.jpg" alt="team3" />
-            </a>
-            <a
-              href="javascript:;"
-              class="avatar avatar-l rounded-circle"
-              data-bs-toggle="tooltip"
-              data-bs-placement="bottom"
-              title
-              data-bs-original-title="Jessica Doe"
-            >
-              <img src="@/assets/img/team-4.jpg" alt="team4" />
+            <a v-for="(friend, index) in detail.friends" :key="index"
+                class="avatar avatar-l rounded-circle"
+                data-bs-toggle="tooltip"
+                data-bs-placement="bottom"
+                title
+                :data-bs-original-title="friend.nickname"
+                @click="moveToFriend(friend.id)"
+              >
+              <img :src="friend.profile" alt="friend" />
             </a>
           </div>
         </div>
@@ -91,9 +61,9 @@
         <div class="row justify-content-center">
           <div class="images-container justify-content-center">
             <div class="image" v-for="(image, index) in detail.adventures" :key="index">
-              <img :src="image.thumbnail" :alt="image.thumbnail" title="thumbnail" />
+              <img class="adventure" :src="image.thumbnail" :alt="image.thumbnail" title="thumbnail" />
               <div class="col-md-4 user-text custom-multi">
-                <img src="@/assets/svg/multi-window-svgrepo-com.svg" alt="Image placeholder" />
+                <img class="adventure" src="@/assets/svg/multi-window-svgrepo-com.svg" alt="Image placeholder" />
               </div>
             </div>
           </div>
@@ -107,7 +77,6 @@
 <script>
 import ArgonButton from "@/items/ArgonButton.vue";
 import { mapGetters, mapState } from "vuex";
-
 const travelStore = "travelStore";
 
 export default {
@@ -123,6 +92,11 @@ export default {
     ...mapGetters(travelStore, ["thumbnail"]),
     isPrivate() {
       return this.travel.travelStatus === "PRIVATE";
+    }
+  },
+  methods: {
+    moveToFriend(userId) {
+      alert(userId);
     }
   },
 };
@@ -197,7 +171,7 @@ export default {
   align-content: center;
   align-items: center;
 }
-img {
+.adventure {
   width: inherit;
   height: inherit;
   object-fit: cover;


### PR DESCRIPTION
## What is this PR?
- 여행 상세보기 기능에서 태그된 친구의 프로필을 띄울 수 있습니다.

## Changes
- 여행 상세보기 기능에서 태그된 친구의 프로필을 띄웁니다.
- 원래는 자신의 프로필을 제외해야 하지만, User 기능을 더 보완해야 이 기능을 완료할 수 있습니다.
- 만들어진 기능은 다음과 같습니다.
  <img width="1412" alt="Screenshot 2023-05-29 at 8 20 39 PM" src="https://github.com/AntAlbum/backend/assets/33994508/663e12d6-a5aa-44e1-aeed-aa188da0050d">

close #26 